### PR TITLE
Make Shell::VERSION available for library users

### DIFF
--- a/lib/shell.rb
+++ b/lib/shell.rb
@@ -17,6 +17,7 @@ require "forwardable"
 require "shell/error"
 require "shell/command-processor"
 require "shell/process-controller"
+require "shell/version"
 
 # Shell implements an idiomatic Ruby interface for common UNIX shell commands.
 #


### PR DESCRIPTION
Now:

``` ruby
require "shell"
Shell::VERSION  #=> "0.7"
```

Before, the version constant was only used in the gemspec.