### PR TITLE
Add missing dependencies

### DIFF
--- a/shell.gemspec
+++ b/shell.gemspec
@@ -36,4 +36,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "e2mmap"
+  spec.add_runtime_dependency "sync"
 end


### PR DESCRIPTION
Ruby 2.7 requires these libraries for both `rake test` and production code.