### PR TITLE
Remove references to `FileTest.exists?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ In this example we will create three `tmpFile`'s in three different folders unde
 
 ```ruby
 sh = Shell.cd("/tmp") # Change to the /tmp directory
-sh.mkdir "shell-test-1" unless sh.exists?("shell-test-1")
+sh.mkdir "shell-test-1" unless sh.exist?("shell-test-1")
 # make the 'shell-test-1' directory if it doesn't already exist
 sh.cd("shell-test-1") # Change to the /tmp/shell-test-1 directory
 for dir in ["dir1", "dir3", "dir5"]
-  if !sh.exists?(dir)
+  if !sh.exist?(dir)
     sh.mkdir dir # make dir if it doesn't already exist
     sh.cd(dir) do
       # change to the `dir` directory
@@ -54,10 +54,10 @@ This example is identical to the first, except we're using `CommandProcessor#tra
 ```ruby
 sh = Shell.cd("/tmp")
 sh.transact do
-  mkdir "shell-test-1" unless exists?("shell-test-1")
+  mkdir "shell-test-1" unless exist?("shell-test-1")
   cd("shell-test-1")
   for dir in ["dir1", "dir3", "dir5"]
-    if !exists?(dir)
+    if !exist?(dir)
       mkdir dir
       cd(dir) do
         f = open("tmpFile", "w")

--- a/lib/shell.rb
+++ b/lib/shell.rb
@@ -32,11 +32,11 @@ require "shell/version"
 # under the +/tmp+ directory.
 #
 #   sh = Shell.cd("/tmp") # Change to the /tmp directory
-#   sh.mkdir "shell-test-1" unless sh.exists?("shell-test-1")
+#   sh.mkdir "shell-test-1" unless sh.exist?("shell-test-1")
 #   # make the 'shell-test-1' directory if it doesn't already exist
 #   sh.cd("shell-test-1") # Change to the /tmp/shell-test-1 directory
 #   for dir in ["dir1", "dir3", "dir5"]
-#     if !sh.exists?(dir)
+#     if !sh.exist?(dir)
 #       sh.mkdir dir # make dir if it doesn't already exist
 #       sh.cd(dir) do
 #         # change to the `dir` directory
@@ -59,10 +59,10 @@ require "shell/version"
 #
 #   sh = Shell.cd("/tmp")
 #   sh.transact do
-#     mkdir "shell-test-1" unless exists?("shell-test-1")
+#     mkdir "shell-test-1" unless exist?("shell-test-1")
 #     cd("shell-test-1")
 #     for dir in ["dir1", "dir3", "dir5"]
-#       if !exists?(dir)
+#       if !exist?(dir)
 # 	  mkdir dir
 # 	  cd(dir) do
 # 	    f = open("tmpFile", "w")

--- a/lib/shell/command-processor.rb
+++ b/lib/shell/command-processor.rb
@@ -157,8 +157,8 @@ class Shell
     #     sh[?e, "foo"]
     #     sh[:e, "foo"]
     #     sh["e", "foo"]
-    #     sh[:exists?, "foo"]
-    #     sh["exists?", "foo"]
+    #     sh[:exist?, "foo"]
+    #     sh["exist?", "foo"]
     #
     def test(command, file1, file2=nil)
       file1 = expand_path(file1)
@@ -360,7 +360,7 @@ class Shell
       return command if /^\// =~ command
       case path = @system_commands[command]
       when String
-        if exists?(path)
+        if exist?(path)
           return path
         else
           Shell.Fail Error::CommandNotFound, command
@@ -485,7 +485,7 @@ class Shell
     # * Shell#directory?(file)
     # * Shell#executable?(file)
     # * Shell#executable_real?(file)
-    # * Shell#exist?(file)/Shell#exists?(file)
+    # * Shell#exist?(file)
     # * Shell#file?(file)
     # * Shell#grpowned?(file)
     # * Shell#owned?(file)


### PR DESCRIPTION
`FileTest.exists?` is removed in Ruby 3.0